### PR TITLE
CMake fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,11 @@
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 cmake_minimum_required(VERSION 3.7.2)
-project("Diet Boom" VERSION 2.0.3 LANGUAGES C)
+project("Diet Boom" VERSION 2.03 LANGUAGES C)
 
-set(PACKAGE_STRING "${PROJECT_NAME} ${PROJECT_VERSION}")
+# Specify the version by hand, because some versions of CMake strip the
+# leading 0 from the minor version number.
+set(PACKAGE_STRING "${PROJECT_NAME} 2.03")
 
 if(MSVC)
     add_definitions("/D_CRT_SECURE_NO_WARNINGS" "/D_CRT_NONSTDC_NO_DEPRECATE")

--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -82,6 +82,7 @@ set(DIETBOOM_SOURCES
     wi_stuff.c wi_stuff.h
     z_zone.c   z_zone.h)
 
-add_executable(dietboom ${DIETBOOM_SOURCES})
+add_executable(dietboom WIN32 ${DIETBOOM_SOURCES})
+target_compile_definitions(dietboom PRIVATE MY_SDL_VER RANGECHECK)
 target_include_directories(dietboom PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/../")
 target_link_libraries(dietboom PRIVATE SDL2::SDL2main SDL2::SDL2 SDL2::mixer SDL2::net)


### PR DESCRIPTION
So when I created my first pull request, I didn't realize that the reason the game didn't start was because I was missing some defines, not because there were some changes in progress.  This fixes that, so now I can compile and play the game with Visual Studio and Visual Studio + Clang.

- Fix project version.  It's 2.03, not 2.0.3.
- Spell out the version in PACKAGE_STRING, since some versions of CMake
   trim leading zeroes from numbers in the version string.
- Set some defines to actually ensure the built program runs properly.